### PR TITLE
feat: add extensible training and infrastructure modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,5 @@
 - Unified previously separate network implementations under a configurable
   ``BaseMRINet`` with optional advanced modules and standardised ``(B, C, D, H, W)``
   tensor shapes.
+- Introduced extensible training framework with experiment tracking, structured
+  logging, data validation utilities and model serving scaffolding.

--- a/data_pipeline.py
+++ b/data_pipeline.py
@@ -13,6 +13,7 @@ import torch
 from torch.utils.data import Dataset, DataLoader
 
 from config import Config
+from data_validation import validate_dataset
 
 try:  # pragma: no cover - optional dependency
     import pydicom
@@ -42,6 +43,11 @@ class MRIDataset(Dataset):
                 self.files.append(p)
             elif p.is_dir() and list(p.glob("*.dcm")):
                 self.files.append(p)
+
+        failed = validate_dataset(self.files)
+        if failed:
+            raise ValueError(f"Invalid imaging files detected: {failed}")
+
         self.compute_statistics()
 
     @lru_cache(maxsize=32)

--- a/data_validation.py
+++ b/data_validation.py
@@ -1,0 +1,55 @@
+"""Data validation utilities for medical imaging datasets."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, List
+
+import numpy as np
+
+try:  # pragma: no cover - optional dependency
+    import pydicom
+except Exception:  # noqa: BLE001
+    pydicom = None
+
+
+def validate_dicom(path: Path) -> bool:
+    """Validate a DICOM file or directory."""
+    if pydicom is None:
+        return True
+    try:
+        if path.is_dir():
+            sample = next(iter(path.glob("*.dcm")))
+            pydicom.dcmread(str(sample))
+        else:
+            pydicom.dcmread(str(path))
+        return True
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def validate_dataset(files: Iterable[Path]) -> List[Path]:
+    """Return a list of files that failed validation checks."""
+    failed: List[Path] = []
+    for p in files:
+        if p.suffix in {".nii", ".nii.gz"}:
+            try:
+                import nibabel as nib  # type: ignore
+
+                nib.load(p)
+            except Exception:  # noqa: BLE001
+                failed.append(p)
+        else:
+            if not validate_dicom(p):
+                failed.append(p)
+    return failed
+
+
+def compute_statistics(volume: np.ndarray) -> dict:
+    """Basic profiling of intensity distribution."""
+    return {
+        "mean": float(volume.mean()),
+        "std": float(volume.std()),
+        "min": float(volume.min()),
+        "max": float(volume.max()),
+    }

--- a/experiment_tracking.py
+++ b/experiment_tracking.py
@@ -1,0 +1,80 @@
+"""Experiment tracking utilities for MRI-KAN."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from packaging import version
+
+
+class ExperimentTracker:
+    """Lightweight wrapper around common experiment tracking frameworks.
+
+    The tracker tries to use Weights & Biases or MLflow if available.  If neither
+    is installed, tracking calls become no-ops which keeps the training loop
+    functional in minimal environments such as unit tests.
+    """
+
+    def __init__(self, project: str = "mri-kan", run_name: Optional[str] = None) -> None:
+        self.project = project
+        self.run_name = run_name
+        self.logger = logging.getLogger(__name__)
+        self._backend: Optional[str] = None
+        self._run: Any = None
+        self._version = version.parse("0.1.0")
+        self._init_backend()
+
+    def _init_backend(self) -> None:
+        try:
+            import wandb
+
+            self._backend = "wandb"
+            self._run = wandb.init(project=self.project, name=self.run_name, reinit=True)
+            self.logger.info("Using Weights & Biases for experiment tracking")
+            return
+        except Exception:  # noqa: BLE001 - optional dependency
+            pass
+        try:
+            import mlflow
+
+            self._backend = "mlflow"
+            mlflow.set_experiment(self.project)
+            self._run = mlflow
+            self.logger.info("Using MLflow for experiment tracking")
+            return
+        except Exception:  # noqa: BLE001 - optional dependency
+            pass
+        self.logger.warning("No experiment tracking backend available; running in no-op mode")
+
+    def log_params(self, params: Dict[str, Any]) -> None:
+        if self._backend == "wandb":
+            self._run.config.update(params, allow_val_change=True)
+        elif self._backend == "mlflow":
+            for k, v in params.items():
+                self._run.log_param(k, v)
+
+    def log_metrics(self, metrics: Dict[str, float], step: int) -> None:
+        if self._backend == "wandb":
+            self._run.log(metrics, step=step)
+        elif self._backend == "mlflow":
+            for k, v in metrics.items():
+                self._run.log_metric(k, v, step=step)
+
+    def log_artifact(self, path: Path) -> None:
+        if self._backend == "wandb":
+            self._run.save(str(path))
+        elif self._backend == "mlflow":
+            self._run.log_artifact(str(path))
+
+    def update_version(self, improved: bool) -> str:
+        """Update semantic version based on performance improvement."""
+        if improved:
+            self._version = version.Version(str(self._version.major) + "." + str(self._version.minor) + "." + str(self._version.micro + 1))
+        return str(self._version)
+
+    def finish(self) -> None:
+        if self._backend == "wandb" and self._run is not None:
+            self._run.finish()
+        self.logger.info("Experiment tracking finished")

--- a/main.py
+++ b/main.py
@@ -1,6 +1,11 @@
+from pathlib import Path
+
+import torch
+
 from multitask_net import MultiTaskMRINet
 from data_loader import get_samples
-from trainer import train_one_epoch, validate
+from losses import MultiTaskLoss
+from trainer import Trainer, TrainingManager
 from predict import predict
 
 
@@ -15,10 +20,26 @@ def main() -> None:
     )
     train_data = get_samples(4)
     val_data = get_samples(2)
-    for epoch in range(2):
-        loss = train_one_epoch(model, train_data)
-        val = validate(model, val_data)
-        print(f"Epoch {epoch+1}: train_loss={loss:.4f} val_loss={val:.4f}")
+    optimizer = torch.optim.SGD(model.parameters(), lr=1e-3)
+    scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=1)
+    loss_fn = MultiTaskLoss({})
+    trainer = Trainer(
+        model=model,
+        loss_fn=loss_fn,
+        optimizer=optimizer,
+        device=torch.device("cpu"),
+        scaler=None,
+        scheduler=scheduler,
+    )
+    manager = TrainingManager(
+        trainer=trainer,
+        train_loader=train_data,
+        val_loader=val_data,
+        epochs=2,
+        out_dir=Path("./"),
+        patience=2,
+    )
+    manager.fit()
     sample = get_samples(1)[0]
     preds = predict(model, sample["mri"][None])
     print("Prediction keys:", list(preds.keys()))

--- a/monitoring.py
+++ b/monitoring.py
@@ -1,0 +1,40 @@
+import logging
+from typing import Optional
+
+# Custom log level for medical data events
+MEDDATA_LEVEL = logging.INFO + 5
+logging.addLevelName(MEDDATA_LEVEL, "MEDDATA")
+
+
+def meddata(self: logging.Logger, message: str, *args, **kwargs) -> None:
+    """Log medical dataset events at MEDDATA level."""
+    if self.isEnabledFor(MEDDATA_LEVEL):
+        self._log(MEDDATA_LEVEL, message, args, **kwargs)
+
+
+logging.Logger.meddata = meddata
+
+
+def setup_logging(level: int = logging.INFO, filename: Optional[str] = None) -> logging.Logger:
+    """Configure structured logging for the application.
+
+    Parameters
+    ----------
+    level: int
+        Logging level for the root logger.
+    filename: Optional[str]
+        Optional log file path. If provided, logs are written to the file in
+        addition to standard output.
+    """
+    handlers = [logging.StreamHandler()]
+    if filename:
+        handlers.append(logging.FileHandler(filename))
+
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
+        handlers=handlers,
+    )
+    logger = logging.getLogger("mri_kan")
+    logger.meddata("Logging initialised")
+    return logger

--- a/serving.py
+++ b/serving.py
@@ -1,0 +1,58 @@
+"""Model serving infrastructure for MRI-KAN."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+import torch
+from fastapi import FastAPI, HTTPException, UploadFile
+from pydantic import BaseModel
+
+from config import Config
+from optimized_network import SOTAMRINetwork
+from monitoring import setup_logging
+
+app = FastAPI(title="MRI-KAN Serving")
+logger = setup_logging()
+
+MODEL: Optional[torch.nn.Module] = None
+DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+
+class PredictionResponse(BaseModel):
+    segmentation: list[int]
+
+
+@app.on_event("startup")
+def load_model() -> None:  # pragma: no cover - executed at runtime
+    """Load model weights at application start."""
+    global MODEL
+    cfg = Config()
+    MODEL = SOTAMRINetwork(cfg)
+    ckpt_path = Path("checkpoints/best.pt")
+    if ckpt_path.exists():
+        state = torch.load(ckpt_path, map_location=DEVICE)
+        MODEL.load_state_dict(state.get("model", state))
+        logger.info("Loaded model checkpoint from %s", ckpt_path)
+    MODEL.to(DEVICE)
+    MODEL.eval()
+
+
+@app.post("/infer", response_model=PredictionResponse)
+async def infer(file: UploadFile) -> PredictionResponse:
+    """Run inference on a single MRI volume provided as a NumPy array."""
+    if MODEL is None:
+        raise HTTPException(status_code=503, detail="Model not loaded")
+    try:
+        contents = await file.read()
+        volume = np.load(file.file if hasattr(file, "file") else file, allow_pickle=True)
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Failed to read input: %s", exc)
+        raise HTTPException(status_code=400, detail="Invalid input") from exc
+    with torch.no_grad():
+        tensor = torch.from_numpy(volume).unsqueeze(0).to(DEVICE)
+        outputs = MODEL(tensor)
+        pred = outputs["segmentation"].argmax(dim=1).cpu().numpy().tolist()[0]
+    return PredictionResponse(segmentation=pred)

--- a/trainer.py
+++ b/trainer.py
@@ -1,102 +1,170 @@
-"""Training utilities for the MRI analysis network."""
+"""Comprehensive training framework for MRI-KAN."""
 
 from __future__ import annotations
 
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Dict, Iterable, Optional
 
-import numpy as np
 import torch
 from torch import Tensor, nn
 
+from experiment_tracking import ExperimentTracker
+from monitoring import setup_logging
 
-def train_one_epoch(
-    model: nn.Module,
-    loader: Iterable[Dict[str, Tensor]],
-    optimizer: torch.optim.Optimizer,
-    loss_fn: nn.Module,
-    device: torch.device,
-    scaler: Optional[torch.cuda.amp.GradScaler] = None,
-    scheduler: Optional[torch.optim.lr_scheduler._LRScheduler] = None,
-    clip_grad: float = 0.0,
-) -> float:
-    """Train ``model`` for a single epoch.
 
-    The function performs a standard training loop with optional mixed
-    precision, gradient clipping and learning rate scheduling.  It returns the
-    average training loss over the epoch.
-    """
+@dataclass
+class Trainer:
+    """Handle a single epoch of training or validation."""
 
-    model.train()
-    epoch_loss = 0.0
-    num_batches = 0
-    for batch in loader:
-        mri = batch["mri"].to(device)
-        targets = {
-            k: v.to(device) for k, v in batch.items() if k in {"seg", "cls", "edge", "tumor"}
-        }
-        optimizer.zero_grad(set_to_none=True)
-        try:
-            with torch.cuda.amp.autocast(enabled=scaler is not None):
-                outputs = model(mri)
-                losses = loss_fn(outputs, targets)
-                loss = losses["total"]
-            if scaler is not None:
-                scaler.scale(loss).backward()
-                if clip_grad > 0:
-                    scaler.unscale_(optimizer)
-                    torch.nn.utils.clip_grad_norm_(model.parameters(), clip_grad)
-                scaler.step(optimizer)
-                scaler.update()
+    model: nn.Module
+    loss_fn: nn.Module
+    optimizer: torch.optim.Optimizer
+    device: torch.device
+    scaler: Optional[torch.cuda.amp.GradScaler] = None
+    scheduler: Optional[torch.optim.lr_scheduler._LRScheduler] = None
+    clip_grad: float = 0.0
+    tracker: Optional[ExperimentTracker] = None
+
+    def __post_init__(self) -> None:
+        self.logger = logging.getLogger(__name__)
+        self.model.to(self.device)
+
+    def _forward(self, batch: Dict[str, Tensor]) -> Dict[str, Tensor]:
+        mri = batch["mri"].to(self.device)
+        return self.model(mri)
+
+    def train_step(self, batch: Dict[str, Tensor]) -> float:
+        self.model.train()
+        self.optimizer.zero_grad(set_to_none=True)
+        targets = {k: v.to(self.device) for k, v in batch.items() if k != "mri"}
+        with torch.cuda.amp.autocast(enabled=self.scaler is not None):
+            outputs = self._forward(batch)
+            losses = self.loss_fn(outputs, targets)
+            loss = losses["total"]
+        if self.scaler is not None:
+            self.scaler.scale(loss).backward()
+            if self.clip_grad > 0:
+                self.scaler.unscale_(self.optimizer)
+                torch.nn.utils.clip_grad_norm_(self.model.parameters(), self.clip_grad)
+            self.scaler.step(self.optimizer)
+            self.scaler.update()
+        else:
+            loss.backward()
+            if self.clip_grad > 0:
+                torch.nn.utils.clip_grad_norm_(self.model.parameters(), self.clip_grad)
+            self.optimizer.step()
+        return float(loss.detach())
+
+    @torch.no_grad()
+    def validate_step(self, batch: Dict[str, Tensor]) -> Dict[str, float]:
+        self.model.eval()
+        outputs = self._forward(batch)
+        targets = {k: v.to(self.device) for k, v in batch.items() if k != "mri"}
+        losses = self.loss_fn(outputs, targets)
+        pred = outputs["segmentation"].argmax(dim=1)
+        dice = self._dice_coefficient(pred, targets["seg"].long())
+        return {"loss": float(losses["total"]), "dice": float(dice)}
+
+    def _dice_coefficient(self, pred: Tensor, target: Tensor) -> float:
+        pred = pred.float()
+        target = target.float()
+        intersection = (pred * target).sum().item()
+        union = pred.sum().item() + target.sum().item()
+        return 2 * intersection / (union + 1e-8)
+
+
+@dataclass
+class TrainingManager:
+    """Manage multi-epoch training with validation and checkpoints."""
+
+    trainer: Trainer
+    train_loader: Iterable[Dict[str, Tensor]]
+    val_loader: Iterable[Dict[str, Tensor]]
+    epochs: int
+    out_dir: Path
+    patience: int = 10
+    tracker: Optional[ExperimentTracker] = None
+    curriculum: Optional[object] = None
+    progressive_resize: Optional[object] = None
+    start_epoch: int = 0
+    best_loss: float = float("inf")
+    logger: logging.Logger = field(default_factory=lambda: setup_logging())
+
+    def fit(self, resume: Optional[str] = None) -> None:
+        if resume:
+            self.load_checkpoint(resume)
+        if self.tracker:
+            self.tracker.log_params({"epochs": self.epochs})
+        epochs_no_improve = 0
+        for epoch in range(self.start_epoch, self.epochs):
+            train_loss = self._train_epoch(epoch)
+            val_metrics = self._validate_epoch(epoch)
+            improved = val_metrics["loss"] < self.best_loss
+            if improved:
+                self.best_loss = val_metrics["loss"]
+                epochs_no_improve = 0
+                self.save_checkpoint(epoch, best=True)
             else:
-                loss.backward()
-                if clip_grad > 0:
-                    torch.nn.utils.clip_grad_norm_(model.parameters(), clip_grad)
-                optimizer.step()
-            epoch_loss += float(loss.detach())
-            num_batches += 1
-        except RuntimeError as exc:  # pragma: no cover - hardware specific
-            if "out of memory" in str(exc):
-                torch.cuda.empty_cache()
-                continue
-            raise
-    if scheduler is not None:
-        scheduler.step()
-    return epoch_loss / max(1, num_batches)
+                epochs_no_improve += 1
+            self.save_checkpoint(epoch)
+            if self.tracker:
+                self.tracker.log_metrics({"train_loss": train_loss, **val_metrics}, step=epoch)
+                self.tracker.update_version(improved)
+            if epochs_no_improve >= self.patience:
+                self.logger.info("Early stopping triggered")
+                break
+        if self.tracker:
+            self.tracker.finish()
 
+    def _train_epoch(self, epoch: int) -> float:
+        losses = []
+        for batch in self.train_loader:
+            try:
+                loss = self.trainer.train_step(batch)
+                losses.append(loss)
+            except RuntimeError as exc:  # pragma: no cover - hardware specific
+                if "out of memory" in str(exc).lower():
+                    self.logger.warning("OOM encountered, skipping batch")
+                    torch.cuda.empty_cache()
+                    continue
+                raise
+        if self.trainer.scheduler is not None:
+            self.trainer.scheduler.step()
+        return float(sum(losses) / max(len(losses), 1))
 
-def _dice_coefficient(pred: Tensor, target: Tensor) -> float:
-    pred = pred.float()
-    target = target.float()
-    intersection = (pred * target).sum().item()
-    union = pred.sum().item() + target.sum().item()
-    return 2 * intersection / (union + 1e-8)
+    def _validate_epoch(self, epoch: int) -> Dict[str, float]:
+        metrics = []
+        for batch in self.val_loader:
+            metrics.append(self.trainer.validate_step(batch))
+        loss = float(sum(m["loss"] for m in metrics) / max(len(metrics), 1))
+        dice = float(sum(m["dice"] for m in metrics) / max(len(metrics), 1))
+        self.logger.info("Epoch %d - val_loss: %.4f dice: %.4f", epoch + 1, loss, dice)
+        return {"loss": loss, "dice": dice}
 
+    def save_checkpoint(self, epoch: int, best: bool = False) -> None:
+        state = {
+            "model": self.trainer.model.state_dict(),
+            "optimizer": self.trainer.optimizer.state_dict(),
+            "scheduler": self.trainer.scheduler.state_dict() if self.trainer.scheduler else None,
+            "scaler": self.trainer.scaler.state_dict() if self.trainer.scaler else None,
+            "epoch": epoch,
+            "best_loss": self.best_loss,
+        }
+        ckpt_path = self.out_dir / ("best.pt" if best else f"epoch_{epoch}.pt")
+        torch.save(state, ckpt_path)
+        if self.tracker:
+            self.tracker.log_artifact(ckpt_path)
 
-def validate(
-    model: nn.Module,
-    loader: Iterable[Dict[str, Tensor]],
-    loss_fn: nn.Module,
-    device: torch.device,
-) -> Dict[str, float]:
-    """Validate ``model`` on ``loader`` without gradient computation."""
-
-    model.eval()
-    val_loss = 0.0
-    dice_scores: list[float] = []
-    num_batches = 0
-    with torch.no_grad():
-        for batch in loader:
-            mri = batch["mri"].to(device)
-            targets = {
-                k: v.to(device) for k, v in batch.items() if k in {"seg", "cls", "edge", "tumor"}
-            }
-            outputs = model(mri)
-            losses = loss_fn(outputs, targets)
-            val_loss += float(losses["total"].detach())
-            pred = outputs["segmentation"].argmax(dim=1).cpu()
-            dice_scores.append(_dice_coefficient(pred, targets["seg"].cpu()))
-            num_batches += 1
-    return {
-        "loss": val_loss / max(1, num_batches),
-        "dice": float(np.mean(dice_scores)) if dice_scores else 0.0,
-    }
+    def load_checkpoint(self, path: str) -> None:
+        ckpt = torch.load(path, map_location=self.trainer.device)
+        self.trainer.model.load_state_dict(ckpt["model"])
+        self.trainer.optimizer.load_state_dict(ckpt["optimizer"])
+        if ckpt.get("scheduler") and self.trainer.scheduler:
+            self.trainer.scheduler.load_state_dict(ckpt["scheduler"])
+        if ckpt.get("scaler") and self.trainer.scaler:
+            self.trainer.scaler.load_state_dict(ckpt["scaler"])
+        self.start_epoch = ckpt.get("epoch", 0) + 1
+        self.best_loss = ckpt.get("best_loss", float("inf"))
+        self.logger.info("Resumed training from %s", path)


### PR DESCRIPTION
## Summary
- rewrite trainer with Trainer and TrainingManager classes including AMP, checkpointing, early stopping, and tracking hooks
- add experiment tracking, monitoring utilities, serving scaffold, and data validation
- update CLI and main to use new training framework

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896df62d61c832cbab2d08b98bd9746